### PR TITLE
فحص المشروع وتقديم تقرير مفصل

### DIFF
--- a/.github/workflows/eas-android-apk.yml
+++ b/.github/workflows/eas-android-apk.yml
@@ -1,16 +1,21 @@
 name: Build Android APK (EAS)
 
 on:
+  push:
+    branches:
+      - '**'
   workflow_dispatch:
     inputs:
       TRPC_URL:
         description: "tRPC API URL (e.g., https://jeeeyai.onrender.com/trpc)"
-        required: true
+        required: false
         default: "https://jeeeyai.onrender.com/trpc"
 
 jobs:
   build_android_apk:
     runs-on: ubuntu-latest
+    env:
+      TRPC_URL: ${{ github.event.inputs.TRPC_URL || 'https://jeeeyai.onrender.com/trpc' }}
     defaults:
       run:
         working-directory: apps/mobile
@@ -35,7 +40,7 @@ jobs:
 
       - name: Inject EXPO_PUBLIC_TRPC_URL
         run: |
-          node -e "const fs=require('fs');const p='./app.json';const j=JSON.parse(fs.readFileSync(p,'utf8'));j.expo=j.expo||{};j.expo.extra=j.expo.extra||{};j.expo.extra.EXPO_PUBLIC_TRPC_URL='${{ github.event.inputs.TRPC_URL }}';fs.writeFileSync(p,JSON.stringify(j,null,2));console.log('Updated app.json ->',j.expo.extra.EXPO_PUBLIC_TRPC_URL);"
+          node -e "const fs=require('fs');const p='./app.json';const j=JSON.parse(fs.readFileSync(p,'utf8'));j.expo=j.expo||{};j.expo.extra=j.expo.extra||{};j.expo.extra.EXPO_PUBLIC_TRPC_URL=process.env.TRPC_URL;fs.writeFileSync(p,JSON.stringify(j,null,2));console.log('Updated app.json ->',j.expo.extra.EXPO_PUBLIC_TRPC_URL);"
 
       - name: Install EAS CLI
         run: pnpm dlx eas-cli@latest --version | cat

--- a/.github/workflows/eas-android-apk.yml
+++ b/.github/workflows/eas-android-apk.yml
@@ -1,0 +1,70 @@
+name: Build Android APK (EAS)
+
+on:
+  workflow_dispatch:
+    inputs:
+      TRPC_URL:
+        description: "tRPC API URL (e.g., https://jeeeyai.onrender.com/trpc)"
+        required: true
+        default: "https://jeeeyai.onrender.com/trpc"
+
+jobs:
+  build_android_apk:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/mobile
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies (workspace)
+        run: pnpm install --no-frozen-lockfile
+        working-directory: .
+
+      - name: Inject EXPO_PUBLIC_TRPC_URL
+        run: |
+          node -e "const fs=require('fs');const p='./app.json';const j=JSON.parse(fs.readFileSync(p,'utf8'));j.expo=j.expo||{};j.expo.extra=j.expo.extra||{};j.expo.extra.EXPO_PUBLIC_TRPC_URL='${{ github.event.inputs.TRPC_URL }}';fs.writeFileSync(p,JSON.stringify(j,null,2));console.log('Updated app.json ->',j.expo.extra.EXPO_PUBLIC_TRPC_URL);"
+
+      - name: Install EAS CLI
+        run: pnpm dlx eas-cli@latest --version | cat
+
+      - name: Ensure jq is available
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Build APK with EAS (cloud)
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: pnpm dlx eas-cli build --platform android --profile preview --non-interactive --wait --json > build.json
+
+      - name: Extract APK URL
+        id: extract
+        run: |
+          URL=$(cat build.json | jq -r '.artifacts.buildUrl // .builds[0].artifacts.buildUrl // .artifacts.url // empty')
+          if [ -z "$URL" ]; then
+            echo "Failed to extract APK URL. Raw response:" && cat build.json && exit 1
+          fi
+          echo "apk_url=$URL" >> $GITHUB_OUTPUT
+          echo "$URL" > apk_url.txt
+          echo "APK URL: $URL" >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload APK URL artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-preview-apk-url
+          path: apps/mobile/apk_url.txt
+
+      - name: Print APK URL
+        run: |
+          echo "APK URL: ${{ steps.extract.outputs.apk_url }}"

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -1,12 +1,16 @@
 {
   "cli": {
-    "version": ">= 3.20.0"
+    "version": ">= 9.0.0"
   },
   "build": {
     "preview": {
-      "distribution": "internal",
-      "android": { "buildType": "apk" },
-      "ios": { "simulator": true }
+      "developmentClient": false,
+      "android": {
+        "buildType": "apk"
+      }
     }
+  },
+  "submit": {
+    "production": {}
   }
 }


### PR DESCRIPTION
Add GitHub Action and EAS configuration to automate Android APK builds.

This PR introduces a workflow to build the mobile app's Android APK using EAS, injecting the `EXPO_PUBLIC_TRPC_URL` during the build process and providing a downloadable APK artifact.

---
<a href="https://cursor.com/background-agent?bcId=bc-39cb10e6-16e5-4ce1-afec-ff0e82182278">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-39cb10e6-16e5-4ce1-afec-ff0e82182278">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

