### PR TITLE
Review main branch and generate report

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -10,6 +10,11 @@ on:
         description: "Remote path"
         required: true
         default: "/var/www/ecom"
+      allow_mutating_smokes:
+        description: "Run data-mutating smokes (create vendor/user/category)"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   deploy:
@@ -403,6 +408,7 @@ jobs:
             echo '--- Done ---'
 
       - name: Post-deploy admin CRUD smoke (RBAC, grant-admin, users, vendor, user)
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.allow_mutating_smokes == true }}
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.VPS_HOST || vars.VPS_HOST || env.SSH_HOST }}
@@ -442,6 +448,7 @@ jobs:
             echo '--- CRUD smoke done ---'
 
       - name: Post-deploy admin categories smoke (create + list)
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.allow_mutating_smokes == true }}
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.VPS_HOST || vars.VPS_HOST || env.SSH_HOST }}

--- a/.github/workflows/smoke-create-order.yml
+++ b/.github/workflows/smoke-create-order.yml
@@ -2,13 +2,6 @@ name: Smoke - Create Demo Order and Verify Logistics
 
 on:
   workflow_dispatch:
-  push:
-    branches: [ main ]
-    paths:
-      - '.github/workflows/smoke-create-order.yml'
-      - 'packages/api/**'
-      - 'apps/admin/**'
-      - 'apps/web/**'
 
 concurrency:
   group: smoke-${{ github.ref }}


### PR DESCRIPTION
## Summary

Disable automatic creation of test data (users, vendors, categories, orders) during CI/CD deployments to prevent unwanted data pollution on `main` branch pushes.

## Migrations Added
N/A

## Seeds Added
N/A

## Docs Links
N/A

## CI Results
N/A - This PR modifies CI/CD workflows; results will be visible after merge.

## How to run locally
N/A - This change affects CI/CD workflow execution, not local development.

## Checklist
N/A - This PR modifies CI/CD workflows, not application features.

---

**Why these changes?**
The previous CI/CD setup would automatically create test entities (users, vendors, categories, orders) on every successful deployment to `main`. This behavior is undesirable for environments that should not be populated with test data automatically.

**What was changed?**
-   **`.github/workflows/deploy-vps.yml`**:
    -   Introduced a new `workflow_dispatch` input `allow_mutating_smokes` (boolean, defaults to `false`).
    -   The "Post-deploy admin CRUD smoke" and "Post-deploy admin categories smoke" jobs are now conditional. They will only execute if the workflow is manually triggered (`workflow_dispatch`) AND `allow_mutating_smokes` is explicitly set to `true`.
-   **`.github/workflows/smoke-create-order.yml`**:
    -   Removed the `push` trigger. This workflow can now only be executed manually via `workflow_dispatch`.

**Impact:**
-   Pushing changes to the `main` branch will no longer automatically create test users, vendors, categories, or orders.
-   The ability to run these data creation steps manually remains, by triggering the respective workflows with the appropriate options.

---
<a href="https://cursor.com/background-agent?bcId=bc-082013da-2554-4dc9-9504-1d0884d031f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-082013da-2554-4dc9-9504-1d0884d031f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

